### PR TITLE
"runs intensity" added

### DIFF
--- a/pproc/DataSetList.R
+++ b/pproc/DataSetList.R
@@ -196,11 +196,16 @@ get_RT_summary.DataSetList <- function(dsList, ftarget, algorithm = 'all') {
   }) %>% rbindlist
 }
 
-get_RT_sample.DataSetList <- function(dsList, ftarget, algorithm = 'all', ...) {
+get_RT_sample.DataSetList <- function(dsList, ftarget, algorithm = 'all') {
   if (algorithm != 'all')
     dsList <- subset(dsList, algId == algorithm)
   
-  lapply(dsList, function(ds) get_RT_sample(ds, ftarget, ...)) %>% rbindlist(fill = T)
+  lapply(dsList, function(ds) {
+    res <- cbind(attr(ds, 'DIM'), attr(ds, 'funcId'), get_RT_sample(ds, ftarget))
+    colnames(res)[1] <- 'DIM'
+    colnames(res)[2] <- 'funcId'
+    res
+  }) %>% rbindlist (fill=TRUE)
 }
 
 get_FV_summary.DataSetList <- function(dsList, runtime, algorithm = 'all') {
@@ -215,11 +220,16 @@ get_FV_summary.DataSetList <- function(dsList, runtime, algorithm = 'all') {
   }) %>% rbindlist
 }
 
-get_FV_sample.DataSetList <- function(dsList, runtime, algorithm = 'all', ...) {
+get_FV_sample.DataSetList <- function(dsList, runtime, algorithm = 'all') {
   if (algorithm != 'all')
     dsList <- subset(dsList, algId == algorithm)
   
-  lapply(dsList, function(ds) get_FV_sample(ds, runtime, ...)) %>% rbindlist(fill = T)
+  lapply(dsList, function(ds) {
+    res <- cbind(attr(ds, 'DIM'), attr(ds, 'funcId'), get_FV_sample(ds, runtime))
+    colnames(res)[1] <- 'DIM'
+    colnames(res)[2] <- 'funcId'
+    res
+  }) %>% rbindlist (fill=TRUE)
 }
 
 get_PAR_summary.DataSetList <- function(dsList, ftarget, algorithm = 'all', ...) {

--- a/pproc/plotDataSetList.R
+++ b/pproc/plotDataSetList.R
@@ -25,13 +25,39 @@ insert_best_parts <- function(from_data, to_data, best_is_min) {
   else
     if (best_is_min)
       pmin(from_data, to_data, na.rm = T)
-  else
-    pmax(from_data, to_data, na.rm = T)
+    else
+      pmax(from_data, to_data, na.rm = T)
 }
+
+generate_rbga <- function(color,a){
+  paste0('rgba(', paste0(color, collapse = ','), ',', a,')')
+}
+
+grad_functions <- c(
+  scaled_edges = function(count, amount, intensity){
+    scale <- (intensity + 1)/2
+    color_end <- floor(scale*amount*2)
+    if (count<color_end)
+      1/color_end
+    else
+      0
+  }
+  ,
+  fixed_edges = function(count, amount, intensity){
+    scale <- (intensity + 1)/2
+    color_center <- floor(scale*amount) + 1
+    if (count<=color_center)
+      1/(2*color_center)
+    else
+      1/(2*(amount-color_center))
+  }
+)
+
 
 plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL, 
                                      show.ERT = T, show.CI = T, show.mean = F,
                                      show.runs = F, show.density = 50,
+                                     show.grad = F, show.intensity = 0,
                                      show.pareto = F, show.optimal = F,
                                      show.median = F, backend = 'plotly',
                                      scale.xlog = F, scale.ylog = F,
@@ -91,24 +117,53 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
                          marker = list(color = rgb_str), legendgroup = legend,
                          line = list(color = rgb_str, dash = 'dot'))
       
-      if (show.runs) {
-        # TODO: Fix this for the case where algorithms do not have the same number of runs
-
+      if (show.runs||show.grad) {
+        
         dr <- get_RT_sample(dsList, Fseq)
         dr_ERT <- dr[algId == attr(dsList[[i]], 'algId')&
                      funcId == attr(dsList[[i]], 'funcId') &
                      DIM == attr(dsList[[i]], 'DIM')]
-        
         names_to_show = sample(colnames(dr_ERT))
         names_to_show <-
-          names_to_show[!names_to_show %in% c('algId', 'target')]
+          names_to_show[!names_to_show %in% c('algId', 'target', 'funcId','DIM')]
         
-        counter <- as.integer(length(names_to_show) * show.density / 100)
+        counter <- as.integer(length(names_to_show) * show.density / 100) + 1
+        fill_density <- 0
+        all_names <- names_to_show
         names_to_show <- head(names_to_show, counter)
         best_parts <- NA
         mentioned <- FALSE
         
+        if (show.grad){
+          sorted_dr_ERT <- apply((dr_ERT[, -c('algId', 'target', 'funcId', 'DIM')]), 1, function(x){sort(x,decreasing = TRUE)})
+          counter = 0
+          names_amount = length(all_names)
+          
+          for (counter in c(1:length(all_names))){
+            fill_density <- fill_density + grad_functions$fixed_edges(counter,names_amount,show.intensity)
+            rgba_str_m  <- generate_rbga(col2rgb(colors[i]),fill_density)
+            p %<>% add_trace(x = dr_ERT[['target']], y = sorted_dr_ERT[counter,],
+                             type = 'scatter', mode = 'none',
+                             hoverinfo = 'none',
+                             showlegend = F,
+                             fill = 'tonexty',
+                             fillcolor = rgba_str_m
+            )
+          }
+          rgba_str_m  <- generate_rbga(col2rgb(colors[i]),1)
+          lower_border <- min(sorted_dr_ERT)
+          p %<>% add_trace(x = dr_ERT[['target']], y = seq(lower_border, lower_border, length.out = length(dr_ERT[['target']])),
+                           type = 'scatter', mode = 'none',
+                           hoverinfo = 'none',
+                           showlegend = F,
+                           fill = 'tonexty',
+                           fillcolor = rgba_str_m
+          )
+        }
+        if (show.runs){
+          
         for (run_v in names_to_show) {
+          if (all(!is.na(dr_ERT[[run_v]]))){
           p %<>% add_trace(
             data = dr_ERT,
             x = ~ target,
@@ -123,7 +178,8 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
           )
           mentioned <- TRUE
           best_parts <-
-            insert_best_parts(best_parts, dr_ERT[[run_v]], TRUE)
+            insert_best_parts(best_parts, dr_ERT[[run_v]], attr(dsList[[i]],"maximization"))
+          }
         }
         
         if (show.optimal) {
@@ -132,7 +188,7 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
           target_idx <- max(NonNAindex)
           
           check_value <- best_parts[target_idx]
-          for (run_v in names_to_show)
+          for (run_v in names_to_show){
             found_val <- dr_ERT[[run_v]][target_idx]
             if (!is.na(found_val) & check_value == found_val) {
               p %<>% add_trace(
@@ -147,6 +203,7 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
               )
               mentioned <- TRUE
             }
+          }
         }
         if (show.pareto) {
           p %<>% add_trace(
@@ -159,7 +216,7 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
             name = paste("pareto_optima.", algId)
           )
         }
-        
+        }
       }
     }
     p %<>%
@@ -187,8 +244,10 @@ plot_RT_line.DataSetList <- function(dsList, Fstart = NULL, Fstop = NULL,
 }
 
 plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
-                                     show.mean = T, show.median = F,
+                                     show.CI = T,
+                                     show.mean = F, show.median = F,
                                      show.runs = F, show.density = 50,
+                                     show.grad = F, show.intensity = 0,
                                      show.pareto = F, show.optimal = F,
                                      backend = 'plotly',
                                      scale.xlog = F, scale.ylog = F,
@@ -225,14 +284,16 @@ plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
       rgb_str <- paste0('rgb(', paste0(col2rgb(colors[i]), collapse = ','), ')')
       rgba_str <- paste0('rgba(', paste0(col2rgb(colors[i]), collapse = ','), ',0.3)')
       
-      p %<>% 
-        add_trace(data = ds_FCE, x = ~runtime, y = ~upper, type = 'scatter', mode = 'lines',
-                  line = list(color = rgba_str, width = 0), legendgroup = legend,
-                  showlegend = F, name = 'mean +/- sd') %>% 
-        add_trace(x = ~runtime, y = ~lower, type = 'scatter', mode = 'lines',
-                  fill = 'tonexty',  line = list(color = 'transparent'),
-                  legendgroup = legend,
-                  fillcolor = rgba_str, showlegend = F, name = 'mean +/- sd')
+      if (show.CI){
+        p %<>% 
+          add_trace(data = ds_FCE, x = ~runtime, y = ~upper, type = 'scatter', mode = 'lines',
+                    line = list(color = rgba_str, width = 0), legendgroup = legend,
+                    showlegend = F, name = 'mean +/- sd') %>% 
+          add_trace(x = ~runtime, y = ~lower, type = 'scatter', mode = 'lines',
+                    fill = 'tonexty',  line = list(color = 'transparent'),
+                    legendgroup = legend,
+                    fillcolor = rgba_str, showlegend = F, name = 'mean +/- sd')
+      }
       
       if (show.mean)
         p %<>% add_trace(data = ds_FCE, x = ~runtime, y = ~mean, type = 'scatter', 
@@ -246,7 +307,7 @@ plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
                          marker = list(color = rgb_str), legendgroup = legend,
                          line = list(color = rgb_str, dash = 'dash'))
       
-      if (show.runs) {
+      if (show.runs||show.grad) {
         fce_runs <- get_FV_sample(dsList, RTseq)
         
         fce_runs_ERT <- fce_runs[algId == attr(dsList[[i]], 'algId') &
@@ -254,12 +315,43 @@ plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
                                  DIM == attr(dsList[[i]], 'DIM')]
         names_to_show <- sample(colnames(fce_runs_ERT))
         names_to_show <-
-          names_to_show[!names_to_show %in% c('algId', 'runtime')]
+          names_to_show[!names_to_show %in% c('algId', 'runtime', 'funcId', 'DIM')]
         
-        counter <- as.integer(length(names_to_show) * show.density / 100)
-        
+        counter <- as.integer(length(names_to_show) * show.density / 100) + 1
+        fill_density <- 0
+        all_names <- names_to_show
         names_to_show <- head(names_to_show, counter)
         best_parts <- NA
+        mentioned <- FALSE
+        
+        if (show.grad){
+          sorted_fce_runs_ERT <- apply((fce_runs_ERT[, -c('algId', 'runtime', 'funcId', 'DIM')]), 1, function(x){sort(x,decreasing = FALSE)})
+          counter = 0
+          names_amount = length(all_names)
+          
+          for (counter in c(1:length(all_names))){
+            fill_density <- fill_density + grad_functions$fixed_edges(counter,names_amount,show.intensity)
+            rgba_str_m  <- generate_rbga(col2rgb(colors[i]),fill_density)
+            p %<>% add_trace(x = fce_runs_ERT[['runtime']], y = sorted_fce_runs_ERT[counter,],
+                             type = 'scatter', mode = 'none',
+                             hoverinfo = 'none',
+                             showlegend = F,
+                             fill = 'tonexty',
+                             fillcolor = rgba_str_m
+            )
+          }
+          rgba_str_m  <- generate_rbga(col2rgb(colors[i]),1)
+          upper_border <- max(sorted_fce_runs_ERT)
+          p %<>% add_trace(x = fce_runs_ERT[['runtime']], y = seq(upper_border, upper_border, length.out = length(fce_runs_ERT[['runtime']])),
+                           type = 'scatter', mode = 'none',
+                           hoverinfo = 'none',
+                           showlegend = F,
+                           fill = 'tonexty',
+                           fillcolor = rgba_str_m
+          )
+        }
+        
+        if (show.runs){
 
         for (run_v in names_to_show) {
           p %<>% add_trace(
@@ -296,6 +388,7 @@ plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
               mentioned = TRUE
             }
         }
+        
         if (show.pareto) {
           p %<>% add_trace(
             x = fce_runs_ERT[['runtime']],
@@ -307,6 +400,7 @@ plot_FV_line.DataSetList <- function(dsList, RTstart = NULL, RTstop = NULL,
             showlegend = T,
             name = paste("pareto_optima.", algId)
           )
+        }
         }
       }
     }

--- a/server.R
+++ b/server.R
@@ -576,6 +576,7 @@ shinyServer(function(input, output, session) {
                               show.runs = input$show_all, show.optimal = input$show.best_of_all,
                               show.pareto = input$show.pareto_optima, show.ERT = input$show.ERT,
                               show.mean = input$show.mean, show.median = input$show.median,
+                              show.grad = input$show_grad, show.intensity = input$show.intensity,
                               scale.xlog = input$semilogx, scale.ylog = input$semilogy,
                               scale.reverse = (src_format == COCO))
 
@@ -968,6 +969,7 @@ shinyServer(function(input, output, session) {
     rt_min <- input$FCE_RT_MIN %>% as.integer
     rt_max <- input$FCE_RT_MAX %>% as.integer
     plot_FV_line.DataSetList(DATA(), RTstart = rt_min, RTstop = rt_max, show.CI = input$show.CI.FCE,
+                             show.grad = input$FCE_show_grad, show.intensity = input$FCE_show.intensity,
                              show.density = input$FCE_show.density, show.pareto = input$FCE_show.pareto_optima,
                              show.runs = input$FCE_show_all, show.optimal = input$FCE_show.best_of_all,
                              show.mean = input$FCE_show.mean, show.median = input$FCE_show.median,

--- a/ui.R
+++ b/ui.R
@@ -309,6 +309,19 @@ body <- dashboardBody(
                                            label = 'scale y axis log10',
                                            value = T),
                              
+                             checkboxInput('show_grad',
+                                           label = 'show runs intensity',
+                                           value = F),
+                             conditionalPanel(condition = "input.show_grad == true",
+                                              
+                                              fluidRow(column(
+                                                11,
+                                                offset = 1,
+                                                sliderInput('show.intensity',
+                                                            label = "Runs intensity(%)",
+                                                            min = -1, max = 1, value = 0, step = 0.1)
+                                              ))),
+                             
                              checkboxInput('show_all',
                                            label = 'show/hide multiple runs',
                                            value = F),
@@ -807,6 +820,19 @@ appear when hovering over the figure. A csv file with the runtime data can be do
                                checkboxInput('FCE_semilogy', 
                                              label = 'scale y axis log10',
                                              value = T),
+                               
+                               checkboxInput('FCE_show_grad',
+                                             label = 'show runs intensity',
+                                             value = F),
+                               conditionalPanel(condition = "input.FCE_show_grad == true",
+                                                
+                                                fluidRow(column(
+                                                  11,
+                                                  offset = 1,
+                                                  sliderInput('FCE_show.intensity',
+                                                              label = "Runs intensity(%)",
+                                                              min = -1, max = 1, value = 0, step = 0.1)
+                                                ))),
                                
                                checkboxInput('FCE_show_all',
                                              label = 'show/hide multiple runs',


### PR DESCRIPTION
Runs gradient implemented
The same way as «multiple runs» checkbox was implemented, «runs intensity» was added. When checkbox is active plotly will draw gradient, which for each point shows percent of runs dominating it. It can help user in analyzing and comparing data.
Along with checkbox, scale «intensity» was added, it allows user to interact with gradient: scale value shows percentage of runs with 50% color intensity.
![int_one-8](https://user-images.githubusercontent.com/18073946/53854270-dbd2f700-3fd9-11e9-86f7-fa5cb567fdcf.png) ![int_one0](https://user-images.githubusercontent.com/18073946/53854275-e1304180-3fd9-11e9-9590-55b951735293.png) ![int_one8](https://user-images.githubusercontent.com/18073946/53854281-e5f4f580-3fd9-11e9-97e4-0d73e32e0ec1.png)

Function of color intensity rescaling is 
`fixed_edges = function(count, amount, intensity){`
    `scale <- (intensity + 1)/2`
    `color_center <- floor(scale*amount) + 1`
    `if (count<=color_center)`
      `1/(2*color_center)`
    `else`
      `1/(2*(amount-color_center))`
  `}`

where «count» is sequence number of intensity, «amount» is total intensities amount, «intensity» is scale value.
_______
«Multiple runs» error was fixed