### PR TITLE
Hide Function selector when a panel with Multiple Functions is selected

### DIFF
--- a/inst/shiny-server/server/settings_page.R
+++ b/inst/shiny-server/server/settings_page.R
@@ -202,6 +202,10 @@ observe({
     shinyjs::show(id = "overall_funcid_box")
     options('IOHanalyzer.function_representation' = 'funcId')
   }
+  if (any(endsWith(input$tabs, c("_multi", "_aggr", "_DSC", "_portfolio")))) {
+    shinyjs::hide(id = "overall_funcname_box")
+    shinyjs::hide(id = "overall_funcid_box")
+  }
 })
 
 observe({


### PR DESCRIPTION
Hello! While my teammates and I were doing the exercises of Carola Doerr's workshop at the SIGEVO Summer School, we were a bit confused about how to select different functions in the Multiple Functions-Cumulative Distribution panel. 

![Screenshot1](https://user-images.githubusercontent.com/30195912/175997754-97326d43-d222-40e9-a632-cd9b0af55df4.png)
We thought we had to select the functions using this selector, but Diederick Vermetten mentioned that the selector doesn't have any use in this mode. 

This pull request hides the function selector when the selected mode is Multiple Functions.

P.S. If you are happy with these changes, I can do a similar thing for the Dimension selector.