### PR TITLE
Bugfix for dynamic attribute reading

### DIFF
--- a/R/readFiles.R
+++ b/R/readFiles.R
@@ -199,7 +199,7 @@ read_index_file__IOH <- function(fname) {
 
 
     if (has_dynattr){
-      attr_list[header$dynamicAttribute] = dynamic_attrs
+      attr_list[[header$dynamicAttribute]] <- dynamic_attrs
     }
 
     # TODO: Make this code more readable


### PR DESCRIPTION
Dynamic attributes were not assigned correctly, leading to falling back on the incorrect infofile reader. This small change fixes that bug.